### PR TITLE
fix(useProgramConfig): add style field to optionSet query fields

### DIFF
--- a/src/hooks/appWrapper/useProgramConfig.ts
+++ b/src/hooks/appWrapper/useProgramConfig.ts
@@ -10,8 +10,8 @@ const PROGRAMQUERY: any = (id: string) => ({
         "access",
         "id,displayName,description,programType,version,translations",
         "trackedEntityType[id,trackedEntityTypeAttributes[trackedEntityAttribute[id]]]",
-        "programTrackedEntityAttributes[name,displayName,mandatory,searchable,displayInList,trackedEntityAttribute[translations,generated,pattern,id,displayName,name,formName,unique,valueType,optionSet[options[translations,code~rename(value),displayName~rename(label)]]]]",
-        "programStages[id,displayName,autoGenerateEvent,repeatable,translations,programStageDataElements[translations,name,displayName,displayInReports,compulsory,dataElement[translations,id,displayName,formName,name,valueType,optionSet[options[translations,code~rename(value),displayName~rename(label)]]]]]"
+        "programTrackedEntityAttributes[name,displayName,mandatory,searchable,displayInList,trackedEntityAttribute[translations,generated,pattern,id,displayName,name,formName,unique,valueType,optionSet[options[translations,style,code~rename(value),displayName~rename(label)]]]]",
+        "programStages[id,displayName,autoGenerateEvent,repeatable,translations,programStageDataElements[translations,name,displayName,displayInReports,compulsory,dataElement[translations,id,displayName,formName,name,valueType,optionSet[options[translations,style,code~rename(value),displayName~rename(label)]]]]]"
       ]
     }
   }


### PR DESCRIPTION
The 'style' field was missing from the optionSet query fields in the PROGRAMQUERY. This field is needed for proper styling of options in the UI.