### PR TITLE
fix(bulkImport): update dropout detection logic to use dataStore values

### DIFF
--- a/src/components/bulk/bulkImport/createEvents/createEventsObject.ts
+++ b/src/components/bulk/bulkImport/createEvents/createEventsObject.ts
@@ -149,7 +149,8 @@ export function generateEnrollmentData(profile: string, programConfig: ProgramCo
 export function generateFinalResultData(
     programStages: string[],
     data: any,
-    programConfig: ProgramConfig
+    programConfig: ProgramConfig,
+    dataStore: any
 ) {
     let enrollmentUpdates: any = []
 
@@ -167,7 +168,7 @@ export function generateFinalResultData(
                 const value = student[programStage][key]
                 if (value) {
                     // Detect "Dropout" in any final-result value (case-insensitive)
-                    if (typeof value === 'string' && value.trim().toLowerCase() === 'dropout') {
+                    if (typeof value === 'string' && dataStore?.finalResult?.dropoutStatusValues?.includes(value)) {
                         isDropout = true
                     }
                 }

--- a/src/components/bulk/bulkImport/useImportData.ts
+++ b/src/components/bulk/bulkImport/useImportData.ts
@@ -99,7 +99,8 @@ export function useImportData({ setProgress, onError, setStats, stats, setOpenPr
                     const { enrollmentUpdates } = generateFinalResultData(
                         displayNames,
                         studentsData,
-                        programConfig
+                        programConfig,
+                        selectedSectionDataStore
                     )
 
                     setProgress((prev: any) => ({ ...prev, progress: 20, buffer: 25 }))


### PR DESCRIPTION
Modify generateFinalResultData to check for dropout status using values from dataStore instead of hardcoded string comparison. This makes the logic more flexible and configurable.