### PR TITLE
refactor: update API parameter names for consistency

### DIFF
--- a/src/components/bulk/bulkExport/exportData.ts
+++ b/src/components/bulk/bulkExport/exportData.ts
@@ -69,11 +69,11 @@ export function useExportData(props: ExportData) {
                                     occurredBefore: getDate({ selectedDate: new Date(endDate) }),
                                 } : {}),
                                 orgUnit,
-                                ouMode: "SELECTED",
+                                orgUnitMode: "SELECTED",
                                 programStage: stagesToExport?.[a],
                                 fields: "event,trackedEntity,occurredAt,enrollment,dataValues[dataElement,value]",
-                                trackedEntity: data?.[teisCounter]?.trackedEntity,
-                                skipPaging: true
+                                trackedEntities: data?.[teisCounter]?.trackedEntity,
+                                paging: false
                             }).then((resp) => {
                                 const events = resp?.filter((x: any) => x.enrollment === data?.[teisCounter]?.enrollment)
                                 const increment = (40 / data?.length) / stagesToExport?.length;

--- a/src/components/bulk/bulkExport/useGetCommonData/commonData.ts
+++ b/src/components/bulk/bulkExport/useGetCommonData/commonData.ts
@@ -16,8 +16,8 @@ export function getCommonSheetData(props: ExportData) {
             fields: "trackedEntity,enrollment,orgUnit,program",
             filter: eventFilters,
             orgUnit,
-            skipPaging: true,
-            ouMode: 'SELECTED',
+            paging: false,
+            orgUnitMode: 'SELECTED',
             order: selectedSectionDataStore?.defaults.defaultOrder
         }).catch((error) => {
             setProgress((progress: any) => ({ ...progress, progress: 100, buffer: 100 }))

--- a/src/components/bulk/bulkImport/postEvents/postAttendance.ts
+++ b/src/components/bulk/bulkImport/postEvents/postAttendance.ts
@@ -43,11 +43,11 @@ export function postAttendanceValues({ setStats, setProgress, onError, setOpenPr
                 program,
                 ...filter,
                 orgUnit,
-                ouMode: "SELECTED",
+                orgUnitMode: "SELECTED",
                 programStage: programStageId,
                 fields: "event,trackedEntity,occurredAt,enrollment,dataValues[dataElement,value]",
-                trackedEntity: trackedEntity,
-                skipPaging: true
+                trackedEntities: trackedEntity,
+                paging: false
             }).then((resp: any[]) => {
 
                 let thisTeiEvents = events.filter(x => x.enrollment === enrollment)

--- a/src/components/bulk/bulkImport/postEvents/postEnrollment.ts
+++ b/src/components/bulk/bulkImport/postEvents/postEnrollment.ts
@@ -39,11 +39,11 @@ export function postEnrollmentData({ setStats, setProgress, onError, setOpenProg
                     await getEvents({
                         program,
                         orgUnit: teis[index]?.orgUnit,
-                        ouMode: "SELECTED",
+                        orgUnitMode: "SELECTED",
                         programStage: socioEconomicsStage,
                         fields: "event,trackedEntity,enrollment,dataValues[dataElement,value]",
-                        trackedEntity: teis[index]?.tei,
-                        skipPaging: true
+                        trackedEntities: teis[index]?.tei,
+                        paging: false
                     }).then((resp: any[]) => {
                         let thisTeiEvent = resp.find(x => x.enrollment === copyData[index].enrollment)
                         const { attributes, ...rest } = copyData[index]

--- a/src/components/bulk/bulkImport/postEvents/postEvents.ts
+++ b/src/components/bulk/bulkImport/postEvents/postEvents.ts
@@ -36,11 +36,11 @@ export function postValues({ setStats, setProgress, onError, setOpenProgress }: 
                 await getEvents({
                     program: programConfig.id,
                     orgUnit,
-                    ouMode: "SELECTED",
+                    orgUnitMode: "SELECTED",
                     programStage: stage,
                     fields: "event,programStage,trackedEntity,occurredAt,enrollment,dataValues[dataElement,value]",
-                    trackedEntity: trackedEntity,
-                    skipPaging: true
+                    trackedEntities: trackedEntity,
+                    paging: false
                 }).then((resp: any) => {
                     let event = resp.find((x: any) => x.enrollment === enrollment && x.programStage == stage)?.event
                     const index = copyData.findIndex(x => x.enrollment === enrollment && x.programStage == stage)

--- a/src/hooks/enrollmentDetails/useGetEnrollmentDetails.ts
+++ b/src/hooks/enrollmentDetails/useGetEnrollmentDetails.ts
@@ -1,7 +1,7 @@
+import { format } from 'date-fns';
+import { Modules } from 'dhis2-semis-types';
 import { ExportData } from '../../types/bulk/bulkOperations';
 import { attributes, dataValues } from '../../utils/format/formatData';
-import { Modules } from 'dhis2-semis-types';
-import { format } from 'date-fns';
 import { useGetEvents, useGetTeis, useUrlParams } from "dhis2-semis-functions";
 
 export function useGetEnrollmentData(props: ExportData) {
@@ -13,10 +13,10 @@ export function useGetEnrollmentData(props: ExportData) {
 
     const getEnrollmentDetails = async (events: any) => {
         const percentagem = module === Modules.Enrollment ? 80 : 40
-        const trackedEntityIds = events?.map((x: { trackedEntity: string }) => x.trackedEntity).join(';')
+        const trackedEntityIds = events?.map((x: { trackedEntity: string }) => x.trackedEntity).join(',')
 
         try {
-            return getTeis({ program: selectedSectionDataStore?.program as unknown as string, trackedEntity: trackedEntityIds, orgUnit })
+            return getTeis({ program: selectedSectionDataStore?.program as unknown as string, trackedEntities: trackedEntityIds, orgUnit })
                 .then(async (trackedEntityInstances: any) => {
                     let rows: any = []
                     let counter = 0
@@ -30,11 +30,11 @@ export function useGetEnrollmentData(props: ExportData) {
                         const registrationData: any = await getEvents({
                             program: selectedSectionDataStore?.program as unknown as string,
                             programStage: selectedSectionDataStore?.registration?.programStage as unknown as string,
-                            ouMode: "SELECTED",
+                            orgUnitMode: "SELECTED",
                             fields: "*",
                             filter: eventFilters,
-                            skipPaging: true,
-                            trackedEntity: tei?.trackedEntity,
+                            paging: false,
+                            trackedEntities: tei?.trackedEntity,
                             orgUnit: orgUnit
                         })
 
@@ -42,11 +42,11 @@ export function useGetEnrollmentData(props: ExportData) {
                             socioEconomiscData = await getEvents({
                                 program: selectedSectionDataStore?.program as unknown as string,
                                 programStage: socioEconomicsStage,
-                                ouMode: "SELECTED",
+                                orgUnitMode: "SELECTED",
                                 fields: "*",
                                 filter: eventFilters,
-                                skipPaging: true,
-                                trackedEntity: tei?.trackedEntity,
+                                paging: false,
+                                trackedEntities: tei?.trackedEntity,
                                 orgUnit: orgUnit
                             })
                         }


### PR DESCRIPTION
- Change `skipPaging` to `paging` with boolean false
- Change `ouMode` to `orgUnitMode`
- Change `trackedEntity` to `trackedEntities` for array parameters
- Standardize parameter naming across bulk export/import components