### PR TITLE
fix(bulkImport): correct program stage mapping in enrollment data generation

### DIFF
--- a/src/components/bulk/bulkImport/createEvents/createEventsObject.ts
+++ b/src/components/bulk/bulkImport/createEvents/createEventsObject.ts
@@ -142,7 +142,6 @@ export function generateEnrollmentData(profile: string, programConfig: ProgramCo
                     programStage: stage.id,
                     ...(updating ? { trackedEntity: student?.Ids?.trackedEntity } : {})
                 })
-                console.log(events, 'aaaaaa')
             }
         }
 

--- a/src/components/bulk/bulkImport/createEvents/createEventsObject.ts
+++ b/src/components/bulk/bulkImport/createEvents/createEventsObject.ts
@@ -116,7 +116,7 @@ export function generateEnrollmentData(profile: string, programConfig: ProgramCo
 
             if (
                 Object.values(dataStore)?.some((dataStoreKey: any) =>
-                    dataStoreKey?.programStage === stage.id || dataStoreKey?.programStages?.includes(stage.id)
+                    dataStoreKey?.programStage === stage.id || dataStoreKey?.programStages?.map((x: any) => x.programStage)?.includes(stage.id)
                 )
             ) {
                 if (student[stage.name]) {
@@ -142,6 +142,7 @@ export function generateEnrollmentData(profile: string, programConfig: ProgramCo
                     programStage: stage.id,
                     ...(updating ? { trackedEntity: student?.Ids?.trackedEntity } : {})
                 })
+                console.log(events, 'aaaaaa')
             }
         }
 


### PR DESCRIPTION
The condition for checking if a program stage exists in dataStore was incorrectly comparing stage IDs. Previously it checked if dataStoreKey.programStages array includes the stage ID directly, but the array contains objects with a programStage property. Now it maps to extract programStage values before checking inclusion.

Also added a temporary debug log to inspect events during development.