### PR TITLE
fix: implement pagination for event fetching in bulk operations

### DIFF
--- a/src/components/bulk/bulkExport/exportData.ts
+++ b/src/components/bulk/bulkExport/exportData.ts
@@ -62,42 +62,51 @@ export function useExportData(props: ExportData) {
                 if (module != Modules.Enrollment) {
                     for (let teisCounter = 0; teisCounter < data?.length; teisCounter++) {
                         for (let a = 0; a < stagesToExport?.length; a++) {
-                            await getEvents({
-                                program: selectedSectionDataStore?.program as unknown as string,
-                                ...(module === Modules.Attendance ? {
-                                    occurredAfter: startDate,
-                                    occurredBefore: getDate({ selectedDate: new Date(endDate) }),
-                                } : {}),
-                                orgUnit,
-                                orgUnitMode: "SELECTED",
-                                programStage: stagesToExport?.[a],
-                                fields: "event,trackedEntity,occurredAt,enrollment,dataValues[dataElement,value]",
-                                trackedEntities: data?.[teisCounter]?.trackedEntity,
-                                paging: false
-                            }).then((resp) => {
-                                const events = resp?.filter((x: any) => x.enrollment === data?.[teisCounter]?.enrollment)
-                                const increment = (40 / data?.length) / stagesToExport?.length;
-                                const bufferIncrement = (41 / data?.length) / stagesToExport?.length;
+                            let events = [], page = 1, pageSize = 50
 
-                                data[teisCounter] = {
-                                    ...data[teisCounter], ...formatSheetData({
-                                        module: module,
-                                        stageId: stagesToExport?.[a],
-                                        events: events,
-                                        dataStore: selectedSectionDataStore as unknown as selectedDataStoreKey
-                                    })
-                                }
+                            do {
+                                events = await getEvents({
+                                    program: selectedSectionDataStore?.program as unknown as string,
+                                    ...(module === Modules.Attendance ? {
+                                        occurredAfter: startDate,
+                                        occurredBefore: getDate({ selectedDate: new Date(endDate) }),
+                                    } : {}),
+                                    orgUnit,
+                                    orgUnitMode: "SELECTED",
+                                    programStage: stagesToExport?.[a],
+                                    fields: "event,trackedEntity,occurredAt,enrollment,dataValues[dataElement,value]",
+                                    trackedEntities: data?.[teisCounter]?.trackedEntity,
+                                    pageSize,
+                                    page
+                                }).then((resp) => {
+                                    page++
+                                    const data = resp?.filter((x: any) => x.enrollment === data?.[teisCounter]?.enrollment)
 
-                                setProgress((prev: any) => ({
-                                    ...prev,
-                                    progress: prev.progress + increment,
-                                    buffer: prev.buffer + bufferIncrement
-                                }));
+                                    data[teisCounter] = {
+                                        ...data[teisCounter], ...formatSheetData({
+                                            module: module,
+                                            stageId: stagesToExport?.[a],
+                                            events: data,
+                                            dataStore: selectedSectionDataStore as unknown as selectedDataStoreKey
+                                        })
+                                    }
 
-                            }).catch((error) => {
-                                setProgress((progress: any) => ({ ...progress, progress: 100, buffer: 100 }))
-                                onError(`Export error: Occurred error wihile fetching data: ${error}`)
-                            })
+                                    return resp
+                                }).catch((error) => {
+                                    setProgress((progress: any) => ({ ...progress, progress: 100, buffer: 100 }))
+                                    onError(`Export error: Occurred error wihile fetching data: ${error}`)
+                                })
+
+                            } while (events?.length == pageSize)
+
+                            const increment = (40 / data?.length) / stagesToExport?.length;
+                            const bufferIncrement = (41 / data?.length) / stagesToExport?.length;
+
+                            setProgress((prev: any) => ({
+                                ...prev,
+                                progress: prev.progress + increment,
+                                buffer: prev.buffer + bufferIncrement
+                            }));
                         }
                     }
                 } else if (empty && module == Modules.Enrollment) {

--- a/src/components/bulk/bulkExport/exportData.ts
+++ b/src/components/bulk/bulkExport/exportData.ts
@@ -62,7 +62,7 @@ export function useExportData(props: ExportData) {
                 if (module != Modules.Enrollment) {
                     for (let teisCounter = 0; teisCounter < data?.length; teisCounter++) {
                         for (let a = 0; a < stagesToExport?.length; a++) {
-                            let events = [], page = 1, pageSize = 50
+                            let events = [], page = 1, pageSize = 10
 
                             do {
                                 events = await getEvents({

--- a/src/components/bulk/bulkExport/exportData.ts
+++ b/src/components/bulk/bulkExport/exportData.ts
@@ -62,7 +62,7 @@ export function useExportData(props: ExportData) {
                 if (module != Modules.Enrollment) {
                     for (let teisCounter = 0; teisCounter < data?.length; teisCounter++) {
                         for (let a = 0; a < stagesToExport?.length; a++) {
-                            let events = [], page = 1, pageSize = 10
+                            let events = [], page = 1, pageSize = 50
 
                             do {
                                 events = await getEvents({

--- a/src/components/bulk/bulkExport/useGetCommonData/commonData.ts
+++ b/src/components/bulk/bulkExport/useGetCommonData/commonData.ts
@@ -5,31 +5,38 @@ import { useGetEnrollmentData } from "../../../../hooks/enrollmentDetails/useGet
 export function getCommonSheetData(props: ExportData) {
     const { getEvents } = useGetEvents()
     const { eventFilters = [], selectedSectionDataStore, setProgress = () => { }, onError } = props
-    const { getEnrollmentDetails  } = useGetEnrollmentData({ ...props, setProgress })
+    const { getEnrollmentDetails } = useGetEnrollmentData({ ...props, setProgress })
     const { urlParameters } = useUrlParams()
     const { school: orgUnit } = urlParameters
 
     async function getData() {
-        const events = await getEvents({
-            program: selectedSectionDataStore?.program as unknown as string,
-            programStage: selectedSectionDataStore?.registration.programStage,
-            fields: "trackedEntity,enrollment,orgUnit,program",
-            filter: eventFilters,
-            orgUnit,
-            paging: false,
-            orgUnitMode: 'SELECTED',
-            order: selectedSectionDataStore?.defaults.defaultOrder
-        }).catch((error) => {
-            setProgress((progress: any) => ({ ...progress, progress: 100, buffer: 100 }))
-            onError('Export Error: ' + error)
-        })
+        let events = [], page = 1, pageSize = 50, fetchedEvents = []
+        do {
+            events = await getEvents({
+                program: selectedSectionDataStore?.program as unknown as string,
+                programStage: selectedSectionDataStore?.registration.programStage,
+                fields: "trackedEntity,enrollment,orgUnit,program",
+                filter: eventFilters,
+                orgUnit,
+                pageSize,
+                page,
+                orgUnitMode: 'SELECTED',
+                order: selectedSectionDataStore?.defaults?.defaultOrder
+            }).catch((error) => {
+                setProgress((progress: any) => ({ ...progress, progress: 100, buffer: 100 }))
+                onError('Export Error: ' + error)
+            })
+
+            fetchedEvents = [...fetchedEvents, ...events]
+            page++
+        } while (events?.length === pageSize)
 
         setProgress((prev: any) => ({ ...prev, progress: 10, buffer: 16 }))
         //verify if events is not empty
-        if (!events || events.length === 0) {
+        if (fetchedEvents.length === 0) {
             return []
         }
-        const enrollmentDetails = await getEnrollmentDetails(events)
+        const enrollmentDetails = await getEnrollmentDetails(fetchedEvents)
 
         return enrollmentDetails
     }

--- a/src/components/bulk/bulkImport/postEvents/postAttendance.ts
+++ b/src/components/bulk/bulkImport/postEvents/postAttendance.ts
@@ -32,6 +32,7 @@ export function postAttendanceValues({ setStats, setProgress, onError, setOpenPr
         const keys = Object.keys(values)
 
         for (const student of excelData as unknown as []) {
+            let page = 1, pageSize = 50, data = []
             const { enrollment, orgUnit, trackedEntity } = (student as unknown as any).Ids
             const days = Object.keys(student[programStageName])
             const filter = {
@@ -39,37 +40,42 @@ export function postAttendanceValues({ setStats, setProgress, onError, setOpenPr
                 occurredBefore: days[days.length - 1]
             }
 
-            await getEvents({
-                program,
-                ...filter,
-                orgUnit,
-                orgUnitMode: "SELECTED",
-                programStage: programStageId,
-                fields: "event,trackedEntity,occurredAt,enrollment,dataValues[dataElement,value]",
-                trackedEntities: trackedEntity,
-                paging: false
-            }).then((resp: any[]) => {
+            do {
+                data = await getEvents({
+                    program,
+                    ...filter,
+                    orgUnit,
+                    orgUnitMode: "SELECTED",
+                    programStage: programStageId,
+                    fields: "event,trackedEntity,occurredAt,enrollment,dataValues[dataElement,value]",
+                    trackedEntities: trackedEntity,
+                    pageSize,
+                    page
+                }).then((resp: any[]) => {
 
-                let thisTeiEvents = events.filter(x => x.enrollment === enrollment)
-                let alreadyExistingEvents: any = {}
+                    let thisTeiEvents = events.filter(x => x.enrollment === enrollment)
+                    let alreadyExistingEvents: any = {}
 
-                resp?.filter(x => x.enrollment === enrollment).map((x) => {
-                    alreadyExistingEvents[format(new Date(x.occurredAt), 'yyyy-MM-dd')] = x.event
+                    resp?.filter(x => x.enrollment === enrollment).map((x) => {
+                        alreadyExistingEvents[format(new Date(x.occurredAt), 'yyyy-MM-dd')] = x.event
+                    })
+
+                    thisTeiEvents.forEach(event => {
+                        if (alreadyExistingEvents[event.occurredAt]) {
+                            values.UPDATE.push({ ...event, event: alreadyExistingEvents[event.occurredAt] });
+                        } else {
+                            values.CREATE.push(event);
+                        }
+                    });
+
+                    page++
+                }).catch((error) => {
+                    setOpenProgress(false)
+                    onError(error)
                 })
+            } while (events?.length == pageSize)
 
-                thisTeiEvents.forEach(event => {
-                    if (alreadyExistingEvents[event.occurredAt]) {
-                        values.UPDATE.push({ ...event, event: alreadyExistingEvents[event.occurredAt] });
-                    } else {
-                        values.CREATE.push(event);
-                    }
-                });
-
-                updateProgressF(40, 35, excelData.length)
-            }).catch((error) => {
-                setOpenProgress(false)
-                onError(error)
-            })
+            updateProgressF(40, 35, excelData.length)
         }
 
         for (const key of keys) {

--- a/src/components/bulk/bulkImport/postEvents/postEnrollment.ts
+++ b/src/components/bulk/bulkImport/postEvents/postEnrollment.ts
@@ -36,34 +36,42 @@ export function postEnrollmentData({ setStats, setProgress, onError, setOpenProg
 
             for (let index = 0; index < teis.length; index++) {
                 if (socioEconomicsStage && !updatingFR) {
-                    await getEvents({
-                        program,
-                        orgUnit: teis[index]?.orgUnit,
-                        orgUnitMode: "SELECTED",
-                        programStage: socioEconomicsStage,
-                        fields: "event,trackedEntity,enrollment,dataValues[dataElement,value]",
-                        trackedEntities: teis[index]?.tei,
-                        paging: false
-                    }).then((resp: any[]) => {
-                        let thisTeiEvent = resp.find(x => x.enrollment === copyData[index].enrollment)
-                        const { attributes, ...rest } = copyData[index]
+                    let page = 1, pageSize = 50, events = []
 
-                        copyData[index] = {
-                            enrollments: [{
-                                ...rest,
-                                events: [...(thisTeiEvent ? [{ ...copyData[index].events[0], event: thisTeiEvent.event }] : [])]
-                            }],
+                    do {
+                        events = await getEvents({
+                            program,
                             orgUnit: teis[index]?.orgUnit,
-                            trackedEntity: teis[index]?.tei,
-                            trackedEntityType: dataStore.trackedEntityType,
-                            attributes: attributes
-                        }
+                            orgUnitMode: "SELECTED",
+                            programStage: socioEconomicsStage,
+                            fields: "event,trackedEntity,enrollment,dataValues[dataElement,value]",
+                            trackedEntities: teis[index]?.tei,
+                            page,
+                            pageSize
+                        }).then((resp: any[]) => {
+                            let thisTeiEvent = resp.find(x => x.enrollment === copyData[index].enrollment)
+                            const { attributes, ...rest } = copyData[index]
 
-                        updateProgressF(updateProgress + 5, updateProgress, teis.length)
-                    }).catch((error) => {
-                        setOpenProgress(false)
-                        onError(error)
-                    })
+                            copyData[index] = {
+                                enrollments: [{
+                                    ...rest,
+                                    events: [...(thisTeiEvent ? [{ ...copyData[index].events[0], event: thisTeiEvent.event }] : [])]
+                                }],
+                                orgUnit: teis[index]?.orgUnit,
+                                trackedEntity: teis[index]?.tei,
+                                trackedEntityType: dataStore.trackedEntityType,
+                                attributes: attributes
+                            }
+                            page++
+
+                            return resp
+                        }).catch((error) => {
+                            setOpenProgress(false)
+                            onError(error)
+                        })
+                    } while (events?.length == pageSize)
+
+                    updateProgressF(updateProgress + 5, updateProgress, teis.length)
                 } else {
                     const { attributes, ...rest } = copyData[index]
                     copyData[index] = updatingFR ? { ...rest, events: [] } : {

--- a/src/components/bulk/bulkImport/postEvents/postEvents.ts
+++ b/src/components/bulk/bulkImport/postEvents/postEvents.ts
@@ -33,24 +33,31 @@ export function postValues({ setStats, setProgress, onError, setOpenProgress }: 
             const { enrollment, orgUnit, trackedEntity } = (student as unknown as any).Ids
 
             for (const stage of programStages) {
-                await getEvents({
-                    program: programConfig.id,
-                    orgUnit,
-                    orgUnitMode: "SELECTED",
-                    programStage: stage,
-                    fields: "event,programStage,trackedEntity,occurredAt,enrollment,dataValues[dataElement,value]",
-                    trackedEntities: trackedEntity,
-                    paging: false
-                }).then((resp: any) => {
-                    let event = resp.find((x: any) => x.enrollment === enrollment && x.programStage == stage)?.event
-                    const index = copyData.findIndex(x => x.enrollment === enrollment && x.programStage == stage)
-                    copyData[index] = { ...copyData[index], ...(event ? { event: event } : {}) }
+                let page = 1, pageSize = 50, events = []
 
-                    updateProgressF(20, 17, excelData.mapping.length * programStages.length)
-                }).catch((error) => {
-                    setOpenProgress(false)
-                    onError(error)
-                })
+                do {
+                    events = await getEvents({
+                        program: programConfig.id,
+                        orgUnit,
+                        orgUnitMode: "SELECTED",
+                        programStage: stage,
+                        fields: "event,programStage,trackedEntity,occurredAt,enrollment,dataValues[dataElement,value]",
+                        trackedEntities: trackedEntity,
+                        page,
+                        pageSize
+                    }).then((resp: any) => {
+                        let event = resp.find((x: any) => x.enrollment === enrollment && x.programStage == stage)?.event
+                        const index = copyData.findIndex(x => x.enrollment === enrollment && x.programStage == stage)
+                        copyData[index] = { ...copyData[index], ...(event ? { event: event } : {}) }
+                        page++
+                        
+                        return resp
+                    }).catch((error) => {
+                        setOpenProgress(false)
+                        onError(error)
+                    })
+                } while (events?.length == pageSize)
+                updateProgressF(20, 17, excelData.mapping.length * programStages.length)
             }
         }
 

--- a/src/hooks/enrollmentDetails/useGetEnrollmentDetails.ts
+++ b/src/hooks/enrollmentDetails/useGetEnrollmentDetails.ts
@@ -11,9 +11,9 @@ export function useGetEnrollmentData(props: ExportData) {
     const { urlParameters } = useUrlParams()
     const { schoolName: orgUnitName, school: orgUnit, } = urlParameters
 
-    const getEnrollmentDetails = async (events: any) => {
+    const getEnrollmentDetails = async (data: any) => {
         const percentagem = module === Modules.Enrollment ? 80 : 40
-        const trackedEntityIds = events?.map((x: { trackedEntity: string }) => x.trackedEntity).join(',')
+        const trackedEntityIds = data?.map((x: { trackedEntity: string }) => x.trackedEntity).join(',')
 
         try {
             return getTeis({ program: selectedSectionDataStore?.program as unknown as string, trackedEntities: trackedEntityIds, orgUnit })
@@ -23,32 +23,45 @@ export function useGetEnrollmentData(props: ExportData) {
 
                     for (const tei of trackedEntityInstances) {
                         counter++
-                        let enrollment = events.find((x: any) => x.trackedEntity == tei?.trackedEntity)?.enrollment
-                        let socioEconomiscData: any = []
+                        let enrollment = data.find((x: any) => x.trackedEntity == tei?.trackedEntity)?.enrollment
+                        let socioEconomiscData: any = [], registrationData = [], page = 1, pageSize = 50, events: any = []
                         const socioEconomicsStage = selectedSectionDataStore?.['socio-economics']?.programStage as unknown as string
 
-                        const registrationData: any = await getEvents({
-                            program: selectedSectionDataStore?.program as unknown as string,
-                            programStage: selectedSectionDataStore?.registration?.programStage as unknown as string,
-                            orgUnitMode: "SELECTED",
-                            fields: "*",
-                            filter: eventFilters,
-                            paging: false,
-                            trackedEntities: tei?.trackedEntity,
-                            orgUnit: orgUnit
-                        })
-
-                        if (socioEconomicsStage && (withSocioEconomics || module === Modules.Enrollment)) {
-                            socioEconomiscData = await getEvents({
+                        do {
+                            events = await getEvents({
                                 program: selectedSectionDataStore?.program as unknown as string,
-                                programStage: socioEconomicsStage,
+                                programStage: selectedSectionDataStore?.registration?.programStage as unknown as string,
                                 orgUnitMode: "SELECTED",
                                 fields: "*",
                                 filter: eventFilters,
-                                paging: false,
                                 trackedEntities: tei?.trackedEntity,
-                                orgUnit: orgUnit
+                                orgUnit: orgUnit,
+                                page,
+                                pageSize
                             })
+
+                            registrationData = [...registrationData, ...events ?? []]
+                            page++
+                        } while (events?.length === pageSize)
+
+                        if (socioEconomicsStage && (withSocioEconomics || module === Modules.Enrollment)) {
+                            page = 1
+                            do {
+                                events = await getEvents({
+                                    program: selectedSectionDataStore?.program as unknown as string,
+                                    programStage: socioEconomicsStage,
+                                    orgUnitMode: "SELECTED",
+                                    fields: "*",
+                                    filter: eventFilters,
+                                    trackedEntities: tei?.trackedEntity,
+                                    orgUnit: orgUnit,
+                                    page,
+                                    pageSize
+                                })
+
+                                socioEconomiscData = [...socioEconomiscData, ...events ?? []]
+                                page++
+                            } while (events?.length === pageSize)
                         }
 
                         const currEnrollmentRegistration = registrationData?.find((x: any) => x.enrollment === enrollment)


### PR DESCRIPTION
Add pagination support to all getEvents calls in bulk export/import components to handle large datasets Replace single paging=false calls with paginated loops using page/pageSize parameters This prevents timeouts and memory issues when fetching large numbers of events