### PR TITLE
fix: remove total count and paging from API calls

### DIFF
--- a/src/components/header/components/orgUnitTreeSearch.tsx
+++ b/src/components/header/components/orgUnitTreeSearch.tsx
@@ -36,7 +36,6 @@ const OrgUnitTree = ({ onChange, stringQuery }) => {
                             'id,displayName,path,publicAccess,access,lastUpdated',
                             'children[id,displayName,publicAccess,access,path,children::isNotEmpty]',
                         ].join(','),
-                        paging: true,
                         query: currentSearchText,
                         withinUserSearchHierarchy: true,
                         pageSize: 15,

--- a/src/components/table/components/pagination/Pagination.tsx
+++ b/src/components/table/components/pagination/Pagination.tsx
@@ -22,7 +22,7 @@ function Pagination({ page, rowsPerPage, onPageChange, onRowsPerPageChange, disa
                     className={defaultClasses.textPagination}
                     value={rowsPerPage}
                     clearValueText={false}
-                    options={rowsPerPages ??  [{ value: 50, label: "50" }, { value: 80, label: "80" }, { value: 120, label: "120" }]}
+                    options={rowsPerPages ??  [{ value: 10, label: "10" }, { value: 50, label: "50" }, { value: 80, label: "80" }, { value: 120, label: "120" }]}
                     clearable={false}
                     searchable={false}
                     onChange={onRowsPerPageChange}

--- a/src/components/table/components/topPaginator/Pagination.tsx
+++ b/src/components/table/components/topPaginator/Pagination.tsx
@@ -19,7 +19,7 @@ function TopPaginator({ page, rowsPerPage, onPageChange, totalData, disablePrevi
             <div />
 
             <div className={defaultClasses.rootPagination}>
-                {TextPagination(`${start} - ${end} of ${totalElements}`)}
+                {TextPagination(`${start} - ${end}`)}
 
                 <div className={defaultClasses.separator} />
 

--- a/src/hooks/enrollmentDetails/useGetEnrollmentDetails.ts
+++ b/src/hooks/enrollmentDetails/useGetEnrollmentDetails.ts
@@ -33,7 +33,6 @@ export function useGetEnrollmentData(props: ExportData) {
                             orgUnitMode: "SELECTED",
                             fields: "*",
                             filter: eventFilters,
-                            paging: false,
                             trackedEntities: tei?.trackedEntity,
                             orgUnit: orgUnit
                         })
@@ -45,7 +44,7 @@ export function useGetEnrollmentData(props: ExportData) {
                                 orgUnitMode: "SELECTED",
                                 fields: "*",
                                 filter: eventFilters,
-                                paging: false,
+
                                 trackedEntities: tei?.trackedEntity,
                                 orgUnit: orgUnit
                             })


### PR DESCRIPTION
- Simplify paginator display by removing total elements count
- Remove paging parameter from org unit tree search query
- Remove paging parameter from enrollment details query to fetch all data at once