### PR TITLE
feat: integrate dataStoreData in bulk import validation

### DIFF
--- a/src/components/bulk/bulkImport/processImport.tsx
+++ b/src/components/bulk/bulkImport/processImport.tsx
@@ -8,8 +8,10 @@ import { useValidateFile, useValidation } from "dhis2-semis-functions";
 import ModalSummaryContent from "../modal/importSummary/importSummary";
 import { TranslationState } from "../../../schemas/translationsSchema";
 import { useRecoilValue } from "recoil";
+import useGetSelectedKeys from "../../../hooks/config/useGetSelectedKeys";
 
 export default function ProcessImport(props: importData) {
+    const { dataStoreData } = useGetSelectedKeys()
     const { label, onError, title, updating, programConfig, module, onClose } = props
     const [progress, setProgress] = useState({ prorocess: "import", progress: 0, buffer: 0 })
     const UseValidation = new useValidation()
@@ -41,7 +43,7 @@ export default function ProcessImport(props: importData) {
         await UseValidation.validation(file[0])
             .then((resp) => {
                 const { mapping, module } = resp
-                validador({ module, data: mapping }).then(() => {
+                validador({ module, data: mapping, dataStore: dataStoreData }).then(() => {
                     setOpen(false)
                     setOpenStats(true)
                 })

--- a/src/hooks/config/useGetSelectedKeys.ts
+++ b/src/hooks/config/useGetSelectedKeys.ts
@@ -1,0 +1,14 @@
+import { useGetSectionTypeLabel } from "dhis2-semis-functions";
+import useProgramsKeys from "../appWrapper/useProgramsKeys";
+import { useDataStoreKey } from "../dataStore/useDataStoreKey";
+
+export default function useGetSelectedKeys() {
+    const programsValues = useProgramsKeys();
+    const { sectionName } = useGetSectionTypeLabel();
+    const dataStoreData = useDataStoreKey({ sectionType: sectionName });
+
+    return {
+        dataStoreData,
+        program: programsValues?.find((program) => program?.id == dataStoreData?.program)
+    }
+}


### PR DESCRIPTION
Use the dataStoreData from useGetSelectedKeys hook to provide additional context during the validation step of the bulk import process. This ensures the validation logic can consider the current program configuration.