### PR TITLE
feat(bulkImport): exclude holiday dates from bulk attendance imports

### DIFF
--- a/src/components/bulk/bulkImport/createEvents/createEventsObject.ts
+++ b/src/components/bulk/bulkImport/createEvents/createEventsObject.ts
@@ -33,8 +33,9 @@ export function generateEventObjects(programStages: string[], data: any, program
     return { events }
 }
 
-export function generateAttendanceEventObjects(programStages: string[], data: any, dataStore: selectedDataStoreKey) {
+export function generateAttendanceEventObjects(programStages: string[], data: any, dataStore: selectedDataStoreKey, schoolCalendar: any) {
     let attendanceEvents: any = []
+    const holidays = schoolCalendar?.holidays?.map((x: any) => x.date) ?? []
 
     for (const student of data) {
         if (!student?.Ids || !student?.Ids?.trackedEntity || !student?.Ids?.orgUnit) {
@@ -44,7 +45,7 @@ export function generateAttendanceEventObjects(programStages: string[], data: an
 
         for (const programStage of programStages) {
             for (const key of Object.keys(student[programStage])) {
-                if (student[programStage][key]) {
+                if (student[programStage][key] && !holidays.includes(key)) {
                     attendanceEvents.push({
                         occurredAt: key,
                         trackedEntity,

--- a/src/components/bulk/bulkImport/useImportData.ts
+++ b/src/components/bulk/bulkImport/useImportData.ts
@@ -5,6 +5,7 @@ import { postAttendanceValues } from "./postEvents/postAttendance";
 import { postEnrollmentData } from "./postEvents/postEnrollment";
 import { postValues } from "./postEvents/postEvents";
 import { useUrlParams } from "dhis2-semis-functions";
+import { useSchoolCalendarKey } from "../../../hooks/dataStore/useSchoolCalendarKey";
 
 type CombinedTypes = importData & excelData & { importMode: "VALIDATE" | "COMMIT" };
 
@@ -13,7 +14,8 @@ export function useImportData({ setProgress, onError, setStats, stats, setOpenPr
     const { postAttendance } = postAttendanceValues({ setStats, setProgress, onError, setOpenProgress })
     const { postEnrollments } = postEnrollmentData({ setStats, setProgress, onError, setOpenProgress })
     const { urlParameters } = useUrlParams()
-    const { school: orgUnit } = urlParameters
+    const { school: orgUnit, academicYear } = urlParameters
+    const { schoolCalendar } = useSchoolCalendarKey()
 
     async function importData(props: CombinedTypes) {
         setProgress((prev: any) => ({ ...prev, progress: 1, buffer: 10 }))
@@ -41,7 +43,9 @@ export function useImportData({ setProgress, onError, setStats, stats, setOpenPr
 
             switch (excelData?.module) {
                 case Modules.Attendance:
-                    const { attendanceEvents } = generateAttendanceEventObjects(displayNames, studentsData, selectedSectionDataStore as unknown as selectedDataStoreKey)
+                    const selectedSchoolCalendar = schoolCalendar?.find(x => x.academicYear?.code === academicYear)
+
+                    const { attendanceEvents } = generateAttendanceEventObjects(displayNames, studentsData, selectedSectionDataStore as unknown as selectedDataStoreKey, selectedSchoolCalendar)
                     const attendanceDisplayName = programConfig?.programStages.find(x => x.id === selectedSectionDataStore?.attendance?.programStage)?.displayName
                     setProgress((prev: any) => ({ ...prev, progress: 20, buffer: 25 }))
 


### PR DESCRIPTION
Extend the generateAttendanceEventObjects function to accept school calendar data, filter out attendance events on holiday dates, and update the useImportData hook to fetch and pass the relevant school calendar based on the academic year URL parameter.