### PR TITLE
feat(header): add TopHeader component with breadcrumb navigation

### DIFF
--- a/src/components/header/topHeader/TopHeader.tsx
+++ b/src/components/header/topHeader/TopHeader.tsx
@@ -1,0 +1,52 @@
+// @ts-ignore
+import { SelectorBar } from '@dhis2/ui';
+import React from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import style from './topHeader.module.css';
+
+export interface TopHeaderProps {
+    studentName?: string;
+    i18n?: any;
+    onBack?: () => void;
+}
+
+export const TopHeader = ({ studentName, i18n, onBack }: TopHeaderProps) => {
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    const handleBack = () => {
+        if (onBack) {
+            onBack();
+        } else {
+            navigate(-1);
+        }
+    };
+
+    const backText = i18n?.t ? i18n.t("Back to Enrollments") : "Back to Enrollments";
+    const enrollmentText = i18n?.t ? i18n.t("Enrollment") : "Enrollment";
+    const defaultStudentName = i18n?.t ? i18n.t("Student Profile") : "Student Profile";
+
+    return (
+        <div className={style.HeaderContainer}>
+            <div className={style.topHeaderContainer}>
+                <button type="button" className={style.backButton} onClick={handleBack}>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <line x1="19" y1="12" x2="5" y2="12"></line>
+                        <polyline points="12 19 5 12 12 5"></polyline>
+                    </svg>
+                    <span>{backText}</span>
+                </button>
+
+                <span className={style.divider}>|</span>
+
+                <div className={style.breadcrumb}>
+                    <span className={style.breadcrumbLabel}>{enrollmentText}</span>
+                    <span className={style.chevron}>›</span>
+                    <span className={style.studentName}>{studentName || defaultStudentName}</span>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default TopHeader;

--- a/src/components/header/topHeader/topHeader.module.css
+++ b/src/components/header/topHeader/topHeader.module.css
@@ -1,0 +1,63 @@
+.HeaderContainer {
+    min-height: 48px;
+    display: flex;
+    align-items: center;
+    background: rgb(255, 255, 255);
+    box-shadow: rgb(213, 221, 229) 0px -1px 0px 0px inset;
+    padding-bottom: 1px;
+}
+
+.topHeaderContainer {
+    display: flex;
+    align-items: center;
+    padding: 8px 16px;
+    width: 100%;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.backButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: none;
+    border: none;
+    padding: 0;
+    color: #1478a6;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.backButton:hover {
+    text-decoration: underline;
+    color: #005a9c;
+}
+
+.divider {
+    margin: 0 12px;
+    color: #c4c4c4;
+    font-size: 14px;
+}
+
+.breadcrumb {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.breadcrumbLabel {
+    color: #6c757d;
+    font-weight: 400;
+}
+
+.chevron {
+    color: #a0aec0;
+    font-size: 14px;
+}
+
+.studentName {
+    color: #1b2533;
+    font-weight: 600;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,11 @@ import { SchoolCalendarData } from './schemas/schoolCalendar'
 import { useSchoolCalendarKey } from "./hooks/dataStore/useSchoolCalendarKey"
 import { useDataStoreStatus } from "./hooks/dataStore/useDataStoreStatus"
 import TestForm from "./components/form/testeForm"
+import TopHeader from "./components/header/topHeader/TopHeader"
 
 export {
     TestForm,
+    TopHeader,
     HeaderValuesState,
     DataStoreState,
     SchoolCalendarData,


### PR DESCRIPTION
- Create TopHeader component with back button and enrollment breadcrumb
- Add i18n support for Back to Enrollments, Enrollment and Student Profile labels
- Support custom onBack handler or default navigate(-1) behavior
- Add topHeader.module.css styles
- Export TopHeader from library index