### PR TITLE
feat(dropdown-button): add full width support

### DIFF
--- a/src/components/buttons/dropdown/DropdownButton.module.css
+++ b/src/components/buttons/dropdown/DropdownButton.module.css
@@ -1,0 +1,3 @@
+.dropDown {
+    width: 100%;
+}

--- a/src/components/buttons/dropdown/DropdownButton.tsx
+++ b/src/components/buttons/dropdown/DropdownButton.tsx
@@ -2,14 +2,16 @@ import React from "react";
 import { SplitButton } from "@dhis2/ui";
 import FlyoutMenu from "../../../components/menu/FlyoutMenu";
 import { DropdownProps } from "../../../types/buttons/DropdownProps";
+import styles from './DropdownButton.module.css'
 
 function CustomDropdown(props: DropdownProps): React.ReactElement {
-  const { name, icon, options, disabled } = props;
+  const { name, icon, options, disabled, fullWidth } = props;
 
   return (
     <SplitButton
       icon={icon}
       disabled={disabled}
+      className={fullWidth && styles.dropDown}
       component={<FlyoutMenu options={options} />}
     >
       {name}

--- a/src/types/buttons/DropdownProps.ts
+++ b/src/types/buttons/DropdownProps.ts
@@ -13,9 +13,10 @@ import { FlyoutOptionsProps } from "../menu/FlyoutMenuProps"
  */
 interface DropdownProps {
     name: string
-    disabled: boolean
+    disabled?: boolean
     icon?: React.ReactElement
     options: FlyoutOptionsProps[]
+    fullWidth?: boolean
 }
 
 export type { DropdownProps }


### PR DESCRIPTION
add DropdownButton.module.css with 100% width styling update DropdownProps to mark disabled as optional and add fullWidth prop apply full width class to SplitButton when prop is provided fix missing newline at end of DropdownProps.ts